### PR TITLE
Add null-handling to GetConfig and test it.

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -88,6 +88,10 @@ func (s *Sdk) GetConfig(key string) (string, error) {
 		return "", err
 	}
 
+	if daemonValue == nil {
+		return "", nil
+	}
+
 	stringValue, ok := daemonValue.(string)
 	if !ok {
 		return "", fmt.Errorf("Received non-string JSON %v", daemonValue)

--- a/state_test.go
+++ b/state_test.go
@@ -111,6 +111,42 @@ func TestGetConfig(t *testing.T) {
 	}
 }
 
+func TestGetConfig_Null(t *testing.T) {
+	expectedResponse := `{"value": null}`
+	expectedBody := map[string]interface{}{
+		"key": "test-key",
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ValidateRequest(t, r, "/config/get")
+
+		var tmp map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&tmp)
+		if err != nil {
+			t.Errorf("Error in decoding response body: %s", err)
+		}
+
+		if !reflect.DeepEqual(tmp, expectedBody) {
+			t.Errorf("Error unexpected request body: %+v", tmp)
+		}
+
+		fmt.Fprintf(w, expectedResponse)
+	}))
+
+	defer ts.Close()
+
+	SetPortVar(t, ts)
+
+	s := NewSdk()
+	output, err := s.GetConfig("test-key")
+	if err != nil {
+		t.Errorf("Error in config request: %v", err)
+	}
+
+	if output != "" {
+		t.Errorf("Error unexpected output: %v", output)
+	}
+}
+
 func TestSetConfig(t *testing.T) {
 	expectedBody := map[string]interface{}{
 		"key":   "key-of-value",


### PR DESCRIPTION
This PR accounts for the possibility that the daemon might return a JSON null in response to a get config call, which it will if the key does not exist in the configuration store.