### PR TITLE
Implement Bold and Italic methods

### DIFF
--- a/print_test.go
+++ b/print_test.go
@@ -4,11 +4,58 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/cto-ai/sdk-go/internal/daemon"
 )
+
+func TestItalic(t *testing.T) {
+	err := os.Setenv("SDK_INTERFACE_TYPE", "terminal")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ux := NewUx()
+	result := ux.Italic("test string")
+	expected := "\033[3mtest string\033[23m"
+	if result != expected {
+		t.Fatalf("in terminal expected %s, got %s", expected, result)
+	}
+
+	err = os.Setenv("SDK_INTERFACE_TYPE", "slack")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result = ux.Italic("test string")
+	expected = "_test string_"
+	if result != expected {
+		t.Fatalf("in Slack expected %s, got %s", expected, result)
+	}
+}
+
+func TestBold(t *testing.T) {
+	err := os.Setenv("SDK_INTERFACE_TYPE", "terminal")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ux := NewUx()
+	result := ux.Bold("test string")
+	expected := "\033[1mtest string\033[0m"
+	if result != expected {
+		t.Fatalf("in terminal expected %s, got %s", expected, result)
+	}
+
+	err = os.Setenv("SDK_INTERFACE_TYPE", "slack")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result = ux.Bold("test string")
+	expected = "*test string*"
+	if result != expected {
+		t.Fatalf("in Slack expected %s, got %s", expected, result)
+	}
+}
 
 func Test_PrintRequest(t *testing.T) {
 	expectedBody := daemon.PrintBody{

--- a/ux.go
+++ b/ux.go
@@ -1,14 +1,34 @@
 package ctoai
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/cto-ai/sdk-go/internal/daemon"
 )
 
 // Ux is the object that contains the UX methods
 type Ux struct{}
 
+// NewUx creates a new Ux object and returns it
 func NewUx() *Ux {
 	return &Ux{}
+}
+
+// Bold adds formatting for boldface type to the given text
+func (*Ux) Bold(text string) string {
+	if os.Getenv("SDK_INTERFACE_TYPE") == "slack" {
+		return fmt.Sprintf("*%s*", text)
+	}
+	return fmt.Sprintf("\033[1m%s\033[0m", text)
+}
+
+// Italic adds formatting for italic type to the given text
+func (*Ux) Italic(text string) string {
+	if os.Getenv("SDK_INTERFACE_TYPE") == "slack" {
+		return fmt.Sprintf("_%s_", text)
+	}
+	return fmt.Sprintf("\033[3m%s\033[23m", text)
 }
 
 // Print prints text to the output interface (i.e. terminal/slack).


### PR DESCRIPTION
This PR adds ux.bold and ux.italic functions to the Go SDK that know to fall back to Slack formatting codes when we're running in that environment.

Partially fulfills https://cto-ai.atlassian.net/browse/ROAD-859