### PR TITLE
fix: ROAD-888: fix datetime prompt

### DIFF
--- a/internal/daemon/prompt_body.go
+++ b/internal/daemon/prompt_body.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // PromptEnvelope is the common fields for all prompt type JSON bodies
@@ -145,8 +144,8 @@ type EditorPromptBody struct {
 // DatetimePromptBody is the JSON body for a datetime prompt
 type DatetimePromptBody struct {
 	PromptEnvelope
-	Variant string    `json:"variant"`
-	Default time.Time `json:"default,omitempty"`
-	Maximum time.Time `json:"maximum,omitempty"`
-	Minimum time.Time `json:"minimum,omitempty"`
+	Variant string `json:"variant"`
+	Default string `json:"default,omitempty"`
+	Maximum string `json:"maximum,omitempty"`
+	Minimum string `json:"minimum,omitempty"`
 }

--- a/prompt.go
+++ b/prompt.go
@@ -598,19 +598,19 @@ func OptDatetimeVariant(variant string) DatetimeOption {
 
 func OptDatetimeDefault(defaultValue time.Time) DatetimeOption {
 	return func(definition *daemon.DatetimePromptBody) {
-		definition.Default = defaultValue
+		definition.Default = defaultValue.Format(time.RFC3339)
 	}
 }
 
 func OptDatetimeMaximum(maximumValue time.Time) DatetimeOption {
 	return func(definition *daemon.DatetimePromptBody) {
-		definition.Maximum = maximumValue
+		definition.Maximum = maximumValue.Format(time.RFC3339)
 	}
 }
 
 func OptDatetimeMinimum(minimumValue time.Time) DatetimeOption {
 	return func(definition *daemon.DatetimePromptBody) {
-		definition.Minimum = minimumValue
+		definition.Minimum = minimumValue.Format(time.RFC3339)
 	}
 }
 


### PR DESCRIPTION
In conjunction with recent changes to the SDK daemon, this PR should fix the datetime prompt to operate correctly when running in the terminal.